### PR TITLE
Late binding of default setTimeout and clearTimeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const createAbortError = () => {
 	return error;
 };
 
-const createDelay = ({clearTimeout: clear = clearTimeout, setTimeout: set = setTimeout, willResolve}) => (ms, {value, signal} = {}) => {
+const createDelay = ({clearTimeout: clear, setTimeout: set, willResolve}) => (ms, {value, signal} = {}) => {
 	if (signal && signal.aborted) {
 		return Promise.reject(createAbortError());
 	}
@@ -14,9 +14,10 @@ const createDelay = ({clearTimeout: clear = clearTimeout, setTimeout: set = setT
 	let timeoutId;
 	let settle;
 	let rejectFn;
+	const c = clear || clearTimeout
 
 	const signalListener = () => {
-		clear(timeoutId);
+		c(timeoutId);
 		rejectFn(createAbortError());
 	};
 
@@ -37,7 +38,7 @@ const createDelay = ({clearTimeout: clear = clearTimeout, setTimeout: set = setT
 		};
 
 		rejectFn = reject;
-		timeoutId = set(settle, ms);
+		timeoutId = (set || setTimeout)(settle, ms);
 	});
 
 	if (signal) {
@@ -45,7 +46,7 @@ const createDelay = ({clearTimeout: clear = clearTimeout, setTimeout: set = setT
 	}
 
 	delayPromise.clear = () => {
-		clear(timeoutId);
+		c(timeoutId);
 		timeoutId = null;
 		cleanup();
 		settle();

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const createDelay = ({clearTimeout: clear, setTimeout: set, willResolve}) => (ms
 	let timeoutId;
 	let settle;
 	let rejectFn;
-	const c = clear || clearTimeout
+	const c = clear || clearTimeout;
 
 	const signalListener = () => {
 		c(timeoutId);


### PR DESCRIPTION
If `setTimeout` and `clearTimeout` aren't explicitly set in the `createDelay()` call, bind their values when the promise is created. This allows `sinon.useFakeTimers()` to work while still allowing other implementations of those functions to be passed to `createDelay()`. Previously the default `setTimeout` and `clearTimeout` were set aside when the module was loaded, meaning default `delay` and `delay.reject` didn't notice if they were later stubbed out.